### PR TITLE
fix pragma syntax for modern Nim

### DIFF
--- a/clblast.nimble
+++ b/clblast.nimble
@@ -1,6 +1,6 @@
 ### Package
 packageName   = "clblast"
-version       = "0.0.1"
+version       = "0.0.2"
 author        = "Mamy André-Ratsimbazafy"
 description   = "A wrapper for CLBlast, an OpenCL BLAS library"
 license       = "Apache License 2.0"

--- a/src/generated/clblast_half.nim
+++ b/src/generated/clblast_half.nim
@@ -1,11 +1,7 @@
-
-
-
 const headerclblast_half = "clblast_half.h"
 type
   half* = cushort
-  ConversionBits* {.importc: "ConversionBits", header: headerclblast_half, bycopy.} = object {.
-      union.}
+  ConversionBits* {.importc: "ConversionBits", header: headerclblast_half, bycopy, union.} = object
     i32* {.importc: "i32".}: cuint
     f32* {.importc: "f32".}: cfloat
 


### PR DESCRIPTION
This causes doc generation of any module that depends on clblast to fail.